### PR TITLE
Handle empty collections

### DIFF
--- a/force-app/main/default/classes/Safely.cls
+++ b/force-app/main/default/classes/Safely.cls
@@ -22,6 +22,9 @@ public with sharing class Safely {
 
     /// Insert
     public List<Database.SaveResult> doInsert(List<SObject> records) {
+        if (records.isEmpty()) {
+            return new List<Database.SaveResult>();
+        }
         if (CanTheUser.create(records)) {
             return doDML(System.AccessType.CREATABLE, records);
         }
@@ -34,6 +37,9 @@ public with sharing class Safely {
 
     /// Update
     public List<Database.SaveResult> doUpdate(List<SObject> records) {
+        if (records.isEmpty()) {
+            return new List<Database.SaveResult>();
+        }
         if (CanTheUser.edit(records)) {
             return doDML(System.AccessType.UPDATABLE, records);
         }
@@ -46,6 +52,9 @@ public with sharing class Safely {
 
     /// Upsert
     public List<Database.UpsertResult> doUpsert(List<SObject> records) {
+        if (records.isEmpty()) {
+            return new List<Database.UpsertResult>();
+        }
         if (CanTheUser.edit(records) && CanTheUser.create(records)) {
             SObjectAccessDecision securityDecision = guardAgainstRemovedFields(
                 AccessType.UPSERTABLE,
@@ -66,6 +75,9 @@ public with sharing class Safely {
 
     /// Delete
     public List<Database.DeleteResult> doDelete(List<SObject> records) {
+        if (records.isEmpty()) {
+            return new List<Database.DeleteResult>();
+        }
         if (CanTheUser.destroy(records)) {
             return Database.delete(records, this.allOrNothing);
         }

--- a/force-app/main/default/tests/Safely_Tests.cls
+++ b/force-app/main/default/tests/Safely_Tests.cls
@@ -391,11 +391,15 @@ private class Safely_Tests {
 	static void emptyCollections(){
 
 		Test.startTest();
-		new Safely().doInsert(new List<Account>());
-		new Safely().doUpdate(new List<Account>());
-		new Safely().doUpsert(new List<Account>());
-		new Safely().doDelete(new List<Account>());
+		List<Database.SaveResult> insertResults = new Safely().doInsert(new List<Account>());
+		List<Database.SaveResult> updateResults = new Safely().doUpdate(new List<Account>());
+		List<Database.UpsertResult> upsertResults = new Safely().doUpsert(new List<Account>());
+		List<Database.DeleteResult> deleteResults = new Safely().doDelete(new List<Account>());
 		Test.stopTest();
 
+		System.assert(insertResults.isEmpty());
+		System.assert(updateResults.isEmpty());
+		System.assert(upsertResults.isEmpty());
+		System.assert(deleteResults.isEmpty());
 	}
 }

--- a/force-app/main/default/tests/Safely_Tests.cls
+++ b/force-app/main/default/tests/Safely_Tests.cls
@@ -386,4 +386,16 @@ private class Safely_Tests {
             );
         }
     }
+
+	@IsTest
+	static void emptyCollections(){
+
+		Test.startTest();
+		new Safely().doInsert(new List<Account>());
+		new Safely().doUpdate(new List<Account>());
+		new Safely().doUpsert(new List<Account>());
+		new Safely().doDelete(new List<Account>());
+		Test.stopTest();
+
+	}
 }


### PR DESCRIPTION
We bypass any permission checks if the user wants to do DML on an empty collection